### PR TITLE
Fix support for checking out tags

### DIFF
--- a/ExtensionLoader.php
+++ b/ExtensionLoader.php
@@ -92,11 +92,11 @@ class ExtensionLoader {
 	 *  );
 	 *
 	 **/
-	public function registerLegacyExtension ( $name, $git, $branch, $specialEntryPointFileName=false ) {
+	public function registerLegacyExtension ( $name, $git, $version, $specialEntryPointFileName=false ) {
 		global $egExtensionLoaderUpdateScript;
 		$this->extensions[$name] = array(
 			'git' => $git,
-			'branch' => $branch,
+			'version' => $version,
 			'specialEntryPointFileName' => $specialEntryPointFileName,
 		);
 		$entryFile = $specialEntryPointFileName ? $specialEntryPointFileName : $name . '.php';
@@ -115,10 +115,10 @@ class ExtensionLoader {
 	 *
 	 *
 	 **/
-	public function load ( $name, $git, $branch ) {
+	public function load ( $name, $git, $version ) {
 		$this->extensions[$name] = array(
 			'git' => $git,
-			'branch' => $branch
+			'version' => $version
 		);
 		wfLoadExtension( $name );
 	}
@@ -139,10 +139,10 @@ class ExtensionLoader {
 	 *
 	 *
 	 **/
-	public function loadSkin ( $name, $git, $branch ) {
+	public function loadSkin ( $name, $git, $version ) {
 		$this->skins[$name] = array(
 			'git' => $git,
-			'branch' => $branch
+			'version' => $version
 		);
 		wfLoadSkin( $name );
 	}

--- a/updateExtensions.php
+++ b/updateExtensions.php
@@ -159,7 +159,7 @@ class ExtensionLoaderUpdateExtensions extends Maintenance {
 		$this->output( shell_exec( "git fetch origin" ) );
 
 		$currentSha1 = shell_exec( "git rev-parse --verify HEAD" );
-		list( $checkoutType, $checkout ) = getCheckoutInfo( $conf['version'] );
+		list( $checkoutType, $checkout ) = $this->getCheckoutInfo( $conf['version'] );
 
 		if ( $checkoutType == "tag" || $checkoutType == "sha1" ) {
 			$fetchedSha1 = shell_exec( "git rev-parse --verify $checkout" );
@@ -246,7 +246,7 @@ class ExtensionLoaderUpdateExtensions extends Maintenance {
 			// not long enough...need at least the first 6 chars of commit hash
 			return false;
 		}
-		elseif ( preg_match( '/[^1234567890abcdef]/', $version ) {
+		elseif ( preg_match( '/[^1234567890abcdef]/', $version ) ) {
 		    // string contains non-hex characters
 			return false;
 		}


### PR DESCRIPTION
In the major change that changed from using a giant array of extensions to single calls to an extension-register function (#7) support was accidentally dropped for checking out git tags. This re-enables that support and makes it much more intuitive than it was before.

Closes #10
