### PR TITLE
Enable skip-log functionality (change parameters to updateExtensions.php)

### DIFF
--- a/updateExtensions.php
+++ b/updateExtensions.php
@@ -105,6 +105,7 @@ class ExtensionLoaderUpdateExtensions extends Maintenance {
 		foreach( $toLoad as $extName ) {
 
 			if ( isset( $skipExtensions[$extName] ) ) {
+				$this->output( "\n## Skipping $extName since it's in skip log $skipLogFile \n" );
 				continue; // in skip log, skip it...
 			}
 
@@ -123,7 +124,9 @@ class ExtensionLoaderUpdateExtensions extends Maintenance {
 		}
 
 		// add any complete extensions to log file.
-		file_put_contents( $skipLogFile, implode( "\n", $completedExtensions), FILE_APPEND );
+		if ( $skipLogFile ) {
+			file_put_contents( $skipLogFile, implode( "\n", $completedExtensions), FILE_APPEND );
+		}
 
 		$this->output( "\n## Finished updating wiki extensions. Remember to run update.php\n" );
 		$this->showErrors();

--- a/updateExtensions.php
+++ b/updateExtensions.php
@@ -96,7 +96,9 @@ class ExtensionLoaderUpdateExtensions extends Maintenance {
 				$skipExtensions = array();
 				foreach ( $skipExtensionsRaw as $extName ) {
 					// cleanup name, turn array around for fast hash table lookup
-					$skipExtensions[ trim($extName) ] = true;
+					if ( trim($extName) !== "" ) {
+						$skipExtensions[ trim($extName) ] = true;
+					}
 				}
 			}
 		}
@@ -125,7 +127,7 @@ class ExtensionLoaderUpdateExtensions extends Maintenance {
 
 		// add any complete extensions to log file.
 		if ( $skipLogFile ) {
-			file_put_contents( $skipLogFile, implode( "\n", $completedExtensions), FILE_APPEND );
+			file_put_contents( $skipLogFile, implode( "\n", $completedExtensions) . "\n", FILE_APPEND );
 		}
 
 		$this->output( "\n## Finished updating wiki extensions. Remember to run update.php\n" );

--- a/updateExtensions.php
+++ b/updateExtensions.php
@@ -42,7 +42,7 @@ class ExtensionLoaderUpdateExtensions extends Maintenance {
 
 		// addOption ($name, $description, $required=false, $withArg=false, $shortName=false)
 		$this->addOption(
-			'only-extensions',
+			'only',
 			'Only update extensions in comma-separated list (no spaces)',
 			false,
 			true
@@ -61,10 +61,10 @@ class ExtensionLoaderUpdateExtensions extends Maintenance {
 
 		$this->extensionLoader = ExtensionLoader::$loader;
 
-		if ( $this->getOption( 'only-extensions' ) ) {
+		if ( $this->getOption( 'only' ) ) {
 			$toLoad = array();
 			$didNotLoad = array();
-			$onlyExtensions = explode( ',', $this->getOption( 'only-extensions' ) );
+			$onlyExtensions = explode( ',', $this->getOption( 'only' ) );
 			foreach ( $onlyExtensions as $ext ) {
 				$ext = trim( $ext );
 				if ( array_key_exists( $ext, $this->extensionLoader->extensions ) ) {

--- a/updateExtensions.php
+++ b/updateExtensions.php
@@ -105,7 +105,7 @@ class ExtensionLoaderUpdateExtensions extends Maintenance {
 		foreach( $toLoad as $extName ) {
 
 			if ( isset( $skipExtensions[$extName] ) ) {
-				$this->output( "\n## Skipping $extName since it's in skip log $skipLogFile \n" );
+				$this->output( "\n## Skipping $extName since it's in skip-log $skipLogFile \n" );
 				continue; // in skip log, skip it...
 			}
 

--- a/updateExtensions.php
+++ b/updateExtensions.php
@@ -38,8 +38,22 @@ class ExtensionLoaderUpdateExtensions extends Maintenance {
 
 	public function __construct() {
 		parent::__construct();
-
 		$this->mDescription = "Update or install extensions managed by ExtensionLoader.";
+
+		// addOption ($name, $description, $required=false, $withArg=false, $shortName=false)
+		$this->addOption(
+			'only-extensions',
+			'Only update extensions in comma-separated list (no spaces)',
+			false,
+			true
+		);
+		$this->addOption(
+			'skip-log',
+			'Ignore extensions already in this log, and add to the log any newly updated extensions',
+			false,
+			true
+		);
+
 	}
 
  	// initiates or updates extensions
@@ -47,19 +61,18 @@ class ExtensionLoaderUpdateExtensions extends Maintenance {
 
 		$this->extensionLoader = ExtensionLoader::$loader;
 
-		if ( $this->getArg(0) ) {
-			$i = 0;
+		if ( $this->getOption( 'only-extensions' ) ) {
 			$toLoad = array();
 			$didNotLoad = array();
-			while ( $this->getArg($i) ) {
-				$ext = $this->getArg($i);
+			$onlyExtensions = explode( ',', $this->getOption( 'only-extensions' ) );
+			foreach ( $onlyExtensions as $ext ) {
+				$ext = trim( $ext );
 				if ( array_key_exists( $ext, $this->extensionLoader->extensions ) ) {
 					$toLoad[] = $ext;
 				}
 				else {
 					$didNotLoad[] = $ext;
 				}
-				$i++;
 			}
 			$this->output( "\nUpdating the following extensions:\n\t" . implode( "\n\t", $toLoad ) . "\n" );
 
@@ -74,7 +87,26 @@ class ExtensionLoaderUpdateExtensions extends Maintenance {
 			$this->output( "Updating all extensions" );
 		}
 
+		// if a log file specified, read from it to determine if any extensions
+		// need to be skipped
+		$skipLogFile = $this->getOption( 'skip-log' );
+		if ( $skipLogFile ) {
+			if ( file_exists( $skipLogFile ) ) {
+				$skipExtensionsRaw = explode( "\n", file_get_contents( $skipLogFile ) );
+				$skipExtensions = array();
+				foreach ( $skipExtensionsRaw as $extName ) {
+					// cleanup name, turn array around for fast hash table lookup
+					$skipExtensions[ trim($extName) ] = true;
+				}
+			}
+		}
+
+		$completedExtensions = array();
 		foreach( $toLoad as $extName ) {
+
+			if ( isset( $skipExtensions[$extName] ) ) {
+				continue; // in skip log, skip it...
+			}
 
 			$extensionDir = $this->extensionLoader->extDir . "/$extName";
 
@@ -86,8 +118,12 @@ class ExtensionLoaderUpdateExtensions extends Maintenance {
 				$this->cloneGitRepo( $extName );
 			}
 
+			$completedExtensions[] = $extName;
+
 		}
 
+		// add any complete extensions to log file.
+		file_put_contents( $skipLogFile, implode( "\n", $completedExtensions), FILE_APPEND );
 
 		$this->output( "\n## Finished updating wiki extensions. Remember to run update.php\n" );
 		$this->showErrors();


### PR DESCRIPTION
This change modifies how `updateExtensions.php` handles parameters. Previously it was called like:

``` bash
php updateExtensions.php SomeExtension SomeOtherExtension AThirdExtension
```

This allowed you to specify which extensions to update. If all extensions were desired, simply don't specify anything, like `php updateExtensions.php`.

**This PR, however, changes that**. Instead, specifying extensions is now done like:

```
php updateExtensions.php --only=SomeExtension,SomeOtherExtension,AThirdExtension
```

In other words, use the `only` option and specify a comma-separated list.

Additionally, there is a `skip-log` option that allows you to specify a file which will be used to determine if any extensions should be skipped (not updated).

So if you had a file `/home/james/skiplog` with the contents:

```
SomeExtension
SomeOtherExtension
AThirdExtension
```

And then ran `php updateExtensions.php --skip-log=/home/james/skiplog` it would update all extensions **except** those listed above. Furthermore, it would append to that log file any extension that were updated (or just checked for updates). So if your wiki had one other extension called "ParserFunctions", then `/home/james/skiplog` would now look like:

```
SomeExtension
SomeOtherExtension
AThirdExtension
ParserFunctions
```

This functionality is being added so several wikis in a Wiki Farm can have their extensions checked for updates, but if one wiki updates an extension in the shared extensions directory then other wikis won't check that same extension for updates.
